### PR TITLE
Backport Adwaita metacity 3 theme for metacity 2

### DIFF
--- a/Adwaita/metacity-1/metacity-theme-2.xml
+++ b/Adwaita/metacity-1/metacity-theme-2.xml
@@ -4,39 +4,42 @@
 	<name>Adwaita</name>
 	<author>GNOME Art Team &lt;art.gnome.org&gt;</author>
 	<copyright>&#194; Intel, &#194; Red Hat, Lapo Calamandrei</copyright>
-	<date>2010</date>
+	<date>2014</date>
 	<description>Default GNOME 3 window theme</description>
 </info>
 
 <!-- meaningfull constants -->
 
-<constant name="C_border_focused" value="blend/#000000/gtk:bg[NORMAL]/0.6" />
+<constant name="C_border_focused" value="blend/#000000/gtk:bg[NORMAL]/0.7" />
 <constant name="C_border_unfocused" value="blend/#000000/gtk:bg[NORMAL]/0.8" />
 <constant name="C_titlebar_focused_hilight" value="gtk:base[NORMAL]" />
 <constant name="C_titlebar_unfocused" value="blend/gtk:base[NORMAL]/gtk:bg[NORMAL]/0.4" />
-<constant name="C_title_focused" value="blend/gtk:fg[NORMAL]/gtk:bg[NORMAL]/0.1" />
+<constant name="C_title_focused" value="gtk:fg[NORMAL]" />
 <constant name="C_title_focused_hilight" value="gtk:base[NORMAL]" />
-<constant name="C_title_unfocused" value="blend/gtk:text[NORMAL]/gtk:bg[NORMAL]/0.9" />
+<constant name="C_title_focused_hilight_dark" value="gtk:bg[NORMAL]" />
+<constant name="C_title_unfocused" value="gtk:fg[INSENSITIVE]" />
 <!-- color of the button icons -->
-<constant name="C_icons_focused" value="gtk:fg[SELECTED]" />
-<constant name="C_icons_focused_pressed" value="gtk:fg[SELECTED]" />
-<constant name="C_icons_unfocused" value="blend/gtk:text[NORMAL]/gtk:bg[NORMAL]/0.9" />
-<constant name="C_icons_unfocused_prelight" value="gtk:bg[NORMAL]" />
-<constant name="C_icons_unfocused_pressed" value="blend/#000000/gtk:bg[NORMAL]/0.7" />
-<constant name="D_icons_unfocused_offset" value="2" /> <!-- offset of the unfocused icons -->
-<constant name="D_icons_shrink" value="1" /> <!-- increasing this value makes the icons in buttons smaller -->
+<constant name="C_icons_focused" value="gtk:fg[NORMAL]" />
+<constant name="C_icons_pressed" value="gtk:fg[NORMAL]" />
+<constant name="C_icons_unfocused" value="gtk:fg[NORMAL]" />
+<constant name="C_icons_unfocused_prelight" value="gtk:fg[NORMAL]" />
+<constant name="C_icons_unfocused_pressed" value="gtk:fg[NORMAL]" />
+<constant name="C_icons_shadow" value="gtk:base[NORMAL]" />
+<constant name="C_separator" value="blend/#000000/gtk:bg[NORMAL]/0.9" />
+<constant name="D_icons_unfocused_offset" value="0" /> <!-- offset of the unfocused icons -->
+<constant name="D_icons_shrink" value="3" /> <!-- increasing this value makes the icons in buttons smaller -->
 <constant name="D_icons_grow" value="0" /> <!-- increasing this value makes the icons in buttons bigger -->
 <!-- geometries -->
 
 <frame_geometry name="normal" title_scale="medium" rounded_top_left="4" rounded_top_right="4">
 	<distance name="left_width" value="1" />
 	<distance name="right_width" value="1" />
-	<distance name="bottom_height" value="2" />
-	<distance name="left_titlebar_edge" value="0"/>
-	<distance name="right_titlebar_edge" value="0"/>
-	<distance name="title_vertical_pad" value="10"/>
-	<border name="title_border" left="10" right="10" top="1" bottom="2"/>
-	<border name="button_border" left="0" right="0" top="1" bottom="2"/>
+	<distance name="bottom_height" value="1" />
+	<distance name="left_titlebar_edge" value="1"/>
+	<distance name="right_titlebar_edge" value="1"/>
+	<distance name="title_vertical_pad" value="16"/>
+	<border name="title_border" left="10" right="10" top="0" bottom="2"/>
+	<border name="button_border" left="0" right="0" top="1" bottom="0"/>
 	<aspect_ratio name="button" value="1"/>
 </frame_geometry>
 
@@ -46,21 +49,19 @@
 </frame_geometry>
 
 <frame_geometry name="max" title_scale="medium" parent="normal" rounded_top_left="false" rounded_top_right="false">
-	<distance name="left_width" value="1" />
-	<distance name="right_width" value="1" />
-	<distance name="left_titlebar_edge" value="0"/>
-	<distance name="right_titlebar_edge" value="0"/>
-	<distance name="title_vertical_pad" value="9"/> <!-- 
+	<distance name="left_width" value="0" />
+	<distance name="right_width" value="0" />
+	<distance name="title_vertical_pad" value="15"/> <!-- 
 							This needs to be 1 less then the
 							title_vertical_pad on normal state
 							or you'll have bigger buttons 								-->
 	<border name="title_border" left="10" right="10" top="1" bottom="2"/>
-	<border name="button_border" left="0" right="0" top="0" bottom="2"/>
-	<distance name="bottom_height" value="1" />
+	<border name="button_border" left="0" right="0" top="0" bottom="0"/>
+	<distance name="bottom_height" value="0" />
 </frame_geometry>
 
 <frame_geometry name="tiled_left" title_scale="medium" rounded_top_left="false" rounded_top_right="false" parent="max">
-	<distance name="right_width" value="1" />
+	<distance name="right_width" value="0" />
 </frame_geometry>
 
 <frame_geometry name="tiled_right" title_scale="medium" rounded_top_left="false" rounded_top_right="false" parent="max">
@@ -81,7 +82,7 @@
 <frame_geometry name="nobuttons" hide_buttons="true" parent="normal">
 </frame_geometry>
 
-<frame_geometry name="borderless" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal" >
+<frame_geometry name="border" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal" >
 	<distance name="left_width" value="1" />
 	<distance name="right_width" value="1" />
 	<distance name="bottom_height" value="1" />
@@ -90,8 +91,24 @@
 	<distance name="title_vertical_pad" value="1" />
 </frame_geometry>
 
-<frame_geometry name="modal" title_scale="small" hide_buttons="true" parent="normal">
-	<distance name="title_vertical_pad" value="9"/>
+<frame_geometry name="borderless" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal" >
+	<distance name="left_width" value="0" />
+	<distance name="right_width" value="0" />
+	<distance name="bottom_height" value="0" />
+	<distance name="title_vertical_pad" value="0" />
+	<border name="button_border" left="0" right="0" top="0" bottom="0"/>
+	<border name="title_border" left="0" right="0" top="0" bottom="0" />
+</frame_geometry>
+
+<frame_geometry name="modal" title_scale="small" hide_buttons="true" rounded_top_left="false" rounded_top_right="false" parent="small">
+	<distance name="title_vertical_pad" value="5"/>
+</frame_geometry>
+
+<frame_geometry name="attached" title_scale="medium" hide_buttons="true" rounded_top_left="4" rounded_top_right="4" rounded_bottom_left="4" rounded_bottom_right="4" parent="normal">
+	<distance name="title_vertical_pad" value="1"/>
+	<distance name="bottom_height" value="1"/>
+	<distance name="left_width" value="1"/>
+	<distance name="right_width" value="1"/>
 </frame_geometry>
 
 <!-- drawing operations -->
@@ -99,16 +116,19 @@
 	<!-- title -->
 
 <draw_ops name="title_focused">
-	<title x="(0 `max` ((width - title_width) / 2)) + 3"
+	<title x="(0 `max` ((width - title_width) / 2))"
                y="(0 `max` ((height - title_height) / 2)) + 2"
                color="C_title_focused_hilight" />
-	<title x="(0 `max` ((width - title_width) / 2)) + 2"
+	<title x="(0 `max` ((width - title_width) / 2))"
+               y="(0 `max` ((height - title_height) / 2))"
+               color="C_title_focused_hilight_dark" />
+	<title x="(0 `max` ((width - title_width) / 2))"
                y="(0 `max` ((height - title_height) / 2)) + 1"
                color="C_title_focused" />
 </draw_ops>
 
 <draw_ops name="title_unfocused">
-	<title x="(0 `max` ((width - title_width) / 2)) + 2"
+	<title x="(0 `max` ((width - title_width) / 2))"
                y="(0 `max` ((height - title_height) / 2)) + 1"
                color="C_title_unfocused"/>
 </draw_ops>
@@ -126,66 +146,48 @@
 <draw_ops name="titlebar_fill_focused">
 	<gradient type="vertical" x="0" y="0" width="width" height="height">
 		<color value="blend/gtk:bg[NORMAL]/gtk:base[NORMAL]/0.4" />
-		<color value="gtk:bg[NORMAL]"/>
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.03" />
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.06" />
+		<color value="gtk:bg[NORMAL]" />
 	</gradient>
 </draw_ops>
 
-<draw_ops name="titlebar_fill_focused_alt">
-	<gradient type="vertical" x="0" y="0" width="width" height="height">
-		<color value="blend/gtk:bg[NORMAL]/gtk:base[NORMAL]/0.6" />
-		<!-- <color value="gtk:bg[NORMAL]"/> -->
-		<!-- <color value="blend/gtk:bg[NORMAL]/#000000/0.03" /> -->
-		<color value="gtk:bg[NORMAL]"/>
-	</gradient>
-</draw_ops>
 
 <draw_ops name="titlebar_fill_unfocused">
 	<rectangle color="C_titlebar_unfocused" x="0" y="0" width="width" height="height" filled="true" />
 </draw_ops>
 
-<draw_ops name="titlebar_unfocused">
-	<include name="titlebar_fill_unfocused" />
-	<line x1="0" y1="height-1" x2="width-1" y2="height-1" color="C_icons_unfocused" />
-</draw_ops>
-
 <draw_ops name="hilight">
 	<line x1="0" y1="1" x2="width-1" y2="1" color="C_titlebar_focused_hilight" />
-	<gradient type="vertical" x="1" y="1" width="1" height="height-4">
-		<color value="C_titlebar_focused_hilight" />
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.03" />
-	</gradient>
 </draw_ops>
 
 <draw_ops name="rounded_hilight">
 	<line x1="5" y1="1" x2="width-6" y2="1" color="C_titlebar_focused_hilight" />
-	<arc color="C_titlebar_focused_hilight" x="1" y="1" width="7" height="7"  start_angle="270" extent_angle="90" />
+	<arc color="C_titlebar_focused_hilight" x="0" y="1" width="8" height="7"  start_angle="270" extent_angle="90" />
 	<arc color="C_titlebar_focused_hilight" x="width-10" y="1" width="9" height="7"  start_angle="0" extent_angle="90" />
-	<gradient type="vertical" x="1" y="5" width="1" height="height-9">
-		<color value="C_titlebar_focused_hilight" />
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.03" />
-	</gradient>
 </draw_ops>
 
 <draw_ops name="titlebar_focused">
-	<include name="titlebar_fill_focused_alt" />
-	<include name="hilight" />
-</draw_ops>
-
-<draw_ops name="titlebar_focused_alt">
-	<include name="titlebar_fill_focused_alt" />
+	<include name="titlebar_fill_focused" />
 	<include name="hilight" />
 </draw_ops>
 
 <draw_ops name="rounded_titlebar_focused">
-	<include name="titlebar_fill_focused_alt" />
+	<include name="titlebar_fill_focused" />
 	<include name="rounded_hilight" />
 </draw_ops>
 
 <draw_ops name="rounded_titlebar_focused_alt">
-	<include name="titlebar_fill_focused_alt" />
+	<include name="titlebar_fill_focused" />
 	<include name="rounded_hilight" />
+</draw_ops>
+
+<draw_ops name="rounded_titlebar_unfocused">
+	<include name="titlebar_fill_unfocused" />
+	<include name="rounded_hilight" />
+</draw_ops>
+
+<draw_ops name="titlebar_unfocused">
+	<include name="titlebar_fill_unfocused" />
+	<include name="hilight" />
 </draw_ops>
 
 <draw_ops name="border_focused">
@@ -215,24 +217,13 @@
 	<line color="C_border_unfocused" x1="width-1" y1="4" x2="width-1" y2="height-2" />
 	<arc color="C_border_unfocused" x="0" y="0" width="9" height="9"  start_angle="270" extent_angle="90" />
 	<arc color="C_border_unfocused" x="width-10" y="0" width="9" height="9"  start_angle="0" extent_angle="90" />
+
 	<!-- double arcs for darker borders -->
 	<arc color="C_border_unfocused" x="0" y="0" width="9" height="9"  start_angle="270" extent_angle="90" />
 	<arc color="C_border_unfocused" x="width-10" y="0" width="9" height="9"  start_angle="0" extent_angle="90" />
 </draw_ops>
 
-<draw_ops name="border_right_focused">
-	<line
-		x1="width-1" y1="0" 
-		x2="width-1" y2="height" 
-		color="C_border_focused" />
-</draw_ops>
 
-<draw_ops name="border_right_unfocused">
-	<line
-		x1="width" y1="0" 
-		x2="width" y2="height" 
-		color="C_border_unfocused" />
-</draw_ops>
 
 <draw_ops name="border_left_focused">
 	<line
@@ -250,34 +241,6 @@
 
 	<!-- button icons-->
 
-<constant name="C_icons_shadow" value="blend/#000000/gtk:bg[NORMAL]/0.6" />
-
-<draw_ops name="close_glyph_focused">
-	<line
-		x1="(width-width%3)/3+D_icons_shrink-D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow" 
-		x2="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow" 
-		color="C_icons_focused" />
-	<line
-		x1="(width-width%3)/3+1+D_icons_shrink-D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow"
-		x2="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y2="height-(height-height%3)/3-2-D_icons_shrink+D_icons_grow"
-		color="C_icons_focused" />
-	<line 
-		x1="(width-width%3)/3+D_icons_shrink-D_icons_grow" y1="(height-height%3)/3+1+D_icons_shrink-D_icons_grow"
-		x2="width-(width-width%3)/3-2-D_icons_shrink+D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow"
-		color="C_icons_focused" />
-	<line 
-		x1="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow"
-		x2="(width-width%3)/3+D_icons_shrink-D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow"
-		color="C_icons_focused" />
-	<line 
-		x1="width-(width-width%3)/3-2-D_icons_shrink+D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow"
-		x2="(width-width%3)/3+D_icons_shrink-D_icons_grow" y2="height-(height-height%3)/3-2-D_icons_shrink+D_icons_grow"
-		color="C_icons_focused" />
-	<line 
-		x1="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y1="(height-height%3)/3+1+D_icons_shrink-D_icons_grow"
-		x2="(width-width%3)/3+1+D_icons_shrink-D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow"
-		color="C_icons_focused" />
-</draw_ops>
 
 <draw_ops name="close_shadow_focused">
 	<line
@@ -306,15 +269,44 @@
 		color="C_icons_shadow" />
 </draw_ops>
 
+<draw_ops name="close_glyph_focused">
+	<line
+		x1="(width-width%3)/3+D_icons_shrink-D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow" 
+		x2="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow" 
+		color="C_icons_focused" />
+	<line
+		x1="(width-width%3)/3+1+D_icons_shrink-D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow"
+		x2="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y2="height-(height-height%3)/3-2-D_icons_shrink+D_icons_grow"
+		color="C_icons_focused" />
+	<line 
+		x1="(width-width%3)/3+D_icons_shrink-D_icons_grow" y1="(height-height%3)/3+1+D_icons_shrink-D_icons_grow"
+		x2="width-(width-width%3)/3-2-D_icons_shrink+D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow"
+		color="C_icons_focused" />
+	<line 
+		x1="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow"
+		x2="(width-width%3)/3+D_icons_shrink-D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow"
+		color="C_icons_focused" />
+	<line 
+		x1="width-(width-width%3)/3-2-D_icons_shrink+D_icons_grow" y1="(height-height%3)/3+D_icons_shrink-D_icons_grow"
+		x2="(width-width%3)/3+D_icons_shrink-D_icons_grow" y2="height-(height-height%3)/3-2-D_icons_shrink+D_icons_grow"
+		color="C_icons_focused" />
+	<line 
+		x1="width-(width-width%3)/3-1-D_icons_shrink+D_icons_grow" y1="(height-height%3)/3+1+D_icons_shrink-D_icons_grow"
+		x2="(width-width%3)/3+1+D_icons_shrink-D_icons_grow" y2="height-(height-height%3)/3-1-D_icons_shrink+D_icons_grow"
+		color="C_icons_focused" />
+</draw_ops>
+
 <draw_ops name="close_focused">
-	<include name="close_shadow_focused" y="1" />
-	<!-- I'm not happy with the current aa I'll draw it twice to make it darker -->
 	<include name="close_shadow_focused" y="1" />
 	<include name="close_glyph_focused" />
 </draw_ops>
 
 <draw_ops name="close_focused_pressed">
-	<include name="close_glyph_focused" y="1" />
+  <include name="close_focused"/>
+</draw_ops>
+
+<draw_ops name="close_focused_prelight">
+  <include name="close_focused"/>
 </draw_ops>
 
 <draw_ops name="close_glyph_unfocused">
@@ -345,7 +337,6 @@
 </draw_ops>
 
 <draw_ops name="close_unfocused">
-	<include name="close_glyph_unfocused" y="D_icons_unfocused_offset" />
 	<include name="close_glyph_unfocused" y="D_icons_unfocused_offset" />
 </draw_ops>
 
@@ -378,7 +369,6 @@
 
 <draw_ops name="close_unfocused_prelight">
 	<include name="close_glyph_unfocused_prelight" y="D_icons_unfocused_offset" />
-	<include name="close_glyph_unfocused_prelight" y="D_icons_unfocused_offset" />
 </draw_ops>
 
 <draw_ops name="close_glyph_unfocused_pressed">
@@ -410,7 +400,6 @@
 
 <draw_ops name="close_unfocused_pressed">
 	<include name="close_glyph_unfocused_pressed" y="D_icons_unfocused_offset" />
-	<include name="close_glyph_unfocused_pressed" y="D_icons_unfocused_offset" />
 </draw_ops>
 
 <draw_ops name="maximize_glyph_focused">
@@ -441,7 +430,11 @@
 </draw_ops>
 
 <draw_ops name="maximize_focused_pressed">
-	<include name="maximize_glyph_focused" y="1" />
+	<include name="maximize_focused" />
+</draw_ops>
+
+<draw_ops name="maximize_focused_prelight">
+	<include name="maximize_focused" />
 </draw_ops>
 
 <draw_ops name="maximize_glyph_unfocused">
@@ -509,7 +502,11 @@
 </draw_ops>
 
 <draw_ops name="minimize_focused_pressed">
-	<include name="minimize_glyph_focused" y="1" />
+	<include name="minimize_focused" />
+</draw_ops>
+
+<draw_ops name="minimize_focused_prelight">
+	<include name="minimize_focused" />
 </draw_ops>
 
 <draw_ops name="minimize_glyph_unfocused">
@@ -581,7 +578,7 @@
 </draw_ops>
 
 <draw_ops name="menu_focused_pressed">
-	<include name="menu_glyph_focused" y="1" />
+	<include name="menu_glyph_focused" />
 </draw_ops>
 
 <draw_ops name="menu_glyph_unfocused">
@@ -641,6 +638,49 @@
 	<include name="menu_glyph_unfocused_pressed" y="D_icons_unfocused_offset" />
 </draw_ops>
 
+<!-- icon size used in GTK -->
+<constant name="D_appmenu_icon_size" value="16" />
+
+<draw_ops name="appmenu_icon_focused">
+        <icon
+		x="(width-D_appmenu_icon_size)/2" y="(height-D_appmenu_icon_size)/2" 
+		width="D_appmenu_icon_size" height="D_appmenu_icon_size" />
+</draw_ops>
+
+<draw_ops name="appmenu_focused">
+        <include name="appmenu_icon_focused" />
+</draw_ops>
+
+<draw_ops name="appmenu_focused_pressed">
+        <include name="appmenu_icon_focused" />
+</draw_ops>
+
+<draw_ops name="appmenu_icon_unfocused">
+        <icon
+		x="(width-D_appmenu_icon_size)/2" y="(height-D_appmenu_icon_size)/2" 
+		width="D_appmenu_icon_size" height="D_appmenu_icon_size"
+		alpha="0.4"/>
+</draw_ops>
+
+<draw_ops name="appmenu_unfocused">
+        <include name="appmenu_icon_unfocused" />
+</draw_ops>
+
+<draw_ops name="appmenu_icon_unfocused_prelight">
+        <icon
+		x="(width-D_appmenu_icon_size)/2" y="(height-D_appmenu_icon_size)/2" 
+		width="D_appmenu_icon_size" height="D_appmenu_icon_size"
+		alpha="0.6"/>
+</draw_ops>
+
+<draw_ops name="appmenu_unfocused_prelight">
+        <include name="appmenu_icon_unfocused_prelight" y="D_icons_unfocused_offset" />
+</draw_ops>
+
+<draw_ops name="appmenu_unfocused_pressed">
+        <include name="appmenu_icon_unfocused_prelight" y="D_icons_unfocused_offset" />
+</draw_ops>
+
 <draw_ops name="shade_glyph_focused">
 	<rectangle 
 		x="(width-width%3)/3+D_icons_shrink-D_icons_grow" y="(height-height%3)/3+D_icons_shrink-D_icons_grow" 
@@ -677,7 +717,7 @@
 </draw_ops>
 
 <draw_ops name="shade_focused_pressed">
-	<include name="shade_glyph_focused" y="1" />
+	<include name="shade_glyph_focused" />
 </draw_ops>
 
 <draw_ops name="shade_glyph_unfocused">
@@ -755,268 +795,50 @@
 <constant name="C_button_border" value="blend/#000000/gtk:bg[NORMAL]/0.8" />
 <constant name="C_button_hilight" value="blend/gtk:base[NORMAL]/gtk:bg[NORMAL]/0.6" />
 
+<draw_ops name="button_border">
+  <line x1="6" y1="4" x2="width-7" y2="4" color="C_button_border" />
+  <arc color="C_button_border" x="width-9" y="4" width="4" height="4" start_angle="0" extent_angle="90"/>  
+  <line x1="width-5" y1="6" x2="width-5" y2="height-7" color="C_button_border" />
+  <arc color="C_button_border" x="width-9" y="height-9" width="4" height="4" start_angle="90" extent_angle="90"/>
+  <line x1="width-6" y1="height-5" x2="6" y2="height-5" color="C_button_border" />
+  <arc color="C_button_border" x="4" y="height-9" width="4" height="4" start_angle="180" extent_angle="90"/>
+  <line x1="4" y1="6" x2="4" y2="height-7" color="C_button_border" />
+  <arc color="C_button_border" x="4" y="4" width="4" height="4" start_angle="270" extent_angle="90"/>
+  <line x1="width-7" y1="height-4" x2="7" y2="height-4" color="C_title_focused_hilight" />
+</draw_ops>
+
+
 <draw_ops name="button_fill"> <!-- button background gradient -->
-	<gradient type="vertical" x="0" y="0" width="width" height="height-2">
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.15" />
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.21" />
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.27" />
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.12" />
-	</gradient>
-</draw_ops>
 
-<draw_ops name="button_bottom">
-	<line x1="0" y1="height-2" x2="width-1" y2="height-2" color="C_button_border" />
-	<line x1="0" y1="height-1" x2="width-1" y2="height-1" color="C_button_hilight" />
-</draw_ops>
-
-<draw_ops name="button_bevel">
-	<gradient type="vertical" x="0" y="0" width="1" height="height-2">
-		<color value="blend/gtk:bg[NORMAL]/gtk:base[NORMAL]/0.1"/>
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.1"/>
-	</gradient>
-	<gradient type="vertical" x="width-1" y="0" width="1" height="height-2">
-		<color value="C_border_focused"/>
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.1"/>
-	</gradient>
 </draw_ops>
 
 <draw_ops name="button_fill_prelight"> <!-- button background gradient for prelight status -->
-	<gradient type="vertical" x="0" y="0" width="width" height="height-2">
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.03" />
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.1" />
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.2" />
-		<color value="blend/gtk:bg[NORMAL]/gtk:fg[NORMAL]/0.04" />
+  <gradient type="vertical" x="5" y="5" width="width-10" height="height-10">
+		<color value="blend/gtk:bg[NORMAL]/gtk:base[NORMAL]/0.6" />
+		<color value="gtk:bg[NORMAL]" />
 	</gradient>
+	<include name="button_border" />
 </draw_ops>
 
 <draw_ops name="button_fill_pressed"> <!-- button background gradient for pressed status -->
-	<gradient type="vertical" x="0" y="0" width="width" height="height-2">
-		<color value="C_border_focused" />
-		<color value="blend/#000000/gtk:bg[NORMAL]/0.75" />
-		<color value="blend/#000000/gtk:bg[NORMAL]/0.8" />
+  <gradient type="vertical" x="5" y="5" width="width-10" height="height-10">
+		<color value="blend/#000000/gtk:bg[NORMAL]/0.89" />
+		<color value="blend/#000000/gtk:bg[NORMAL]/0.9" />
 	</gradient>
+  <line x1="5" y1="5" x2="width-6" y2="5" color="blend/#000000/gtk:bg[NORMAL]/0.765" />
+  <line x1="4" y1="6" x2="width-5" y2="6" color="blend/#000000/gtk:bg[NORMAL]/0.85" />
+	<include name="button_border" />
 </draw_ops>
 
 <draw_ops name="button">
-	<include name="button_fill" />
-	<include name="button_bevel" />
-	<include name="button_bottom" />
 </draw_ops>
 
 <draw_ops name="button_prelight">
 	<include name="button_fill_prelight" />
-	<include name="button_bevel" />
-	<include name="button_bottom" />
 </draw_ops>
 
 <draw_ops name="button_pressed">
 	<include name="button_fill_pressed" />
-	<include name="button_bottom" />
-</draw_ops>
-
-<!-- things get messy here -->
-
-<draw_ops name="button_inner_right_slice1">
-	<clip x="0" y="0" width="width" height="height-5" />
-	<include name="button" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice2">
-	<clip x="1" y="height-5" width="width-1" height="2" />
-	<include name="button" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice3">
-	<clip x="2" y="height-3" width="width-2" height="1" />
-	<include name="button" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice4">
-	<clip x="4" y="height-2" width="width-4" height="2" />
-	<include name="button" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_fill">
-	<include name="button_inner_right_slice1" />
-	<include name="button_inner_right_slice2" />
-	<include name="button_inner_right_slice3" />
-	<include name="button_inner_right_slice4" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_slice1_prelight">
-	<clip x="0" y="0" width="width" height="height-5" />
-	<include name="button_prelight" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice2_prelight">
-	<clip x="1" y="height-5" width="width-1" height="2" />
-	<include name="button_prelight" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice3_prelight">
-	<clip x="2" y="height-3" width="width-2" height="1" />
-	<include name="button_prelight" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice4_prelight">
-	<clip x="4" y="height-2" width="width-4" height="2" />
-	<include name="button_prelight" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_fill_prelight">
-	<include name="button_inner_right_slice1_prelight" />
-	<include name="button_inner_right_slice2_prelight" />
-	<include name="button_inner_right_slice3_prelight" />
-	<include name="button_inner_right_slice4_prelight" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_slice1_pressed">
-	<clip x="0" y="0" width="width" height="height-5" />
-	<include name="button_pressed" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice2_pressed">
-	<clip x="1" y="height-5" width="width-1" height="2" />
-	<include name="button_pressed" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice3_pressed">
-	<clip x="2" y="height-3" width="width-2" height="1" />
-	<include name="button_pressed" />
-</draw_ops>
-<draw_ops name="button_inner_right_slice4_pressed">
-	<clip x="4" y="height-2" width="width-4" height="2" />
-	<include name="button_pressed" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_fill_pressed">
-	<include name="button_inner_right_slice1_pressed" />
-	<include name="button_inner_right_slice2_pressed" />
-	<include name="button_inner_right_slice3_pressed" />
-	<include name="button_inner_right_slice4_pressed" />
-</draw_ops>
-
-
-<draw_ops name="button_inner_right_border">
-	<gradient type="vertical" x="0" y="0" width="1" height="height-5">
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.06" />
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.06" />
-		<color value="blend/gtk:bg[NORMAL]/#000000/0.03" />
-	</gradient>
-	<arc color="C_button_hilight" x="1" y="height-10" width="9" height="9"  start_angle="180" extent_angle="90" />
-	<gradient type="vertical" x="1" y="0" width="1" height="height-5">
-		<color value="C_border_focused" />
-		<color value="C_button_border" />
-	</gradient>
-	<arc color="C_button_border" x="1" y="height-11" width="9" height="9"  start_angle="180" extent_angle="90" />
-</draw_ops>
-
-<draw_ops name="button_inner_right">
-	<include name="button_inner_right_fill" />
-	<include name="button_inner_right_border" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_prelight">
-	<include name="button_inner_right_fill_prelight" />
-	<include name="button_inner_right_border" />
-</draw_ops>
-
-<draw_ops name="button_inner_right_pressed">
-	<include name="button_inner_right_fill_pressed" />
-	<include name="button_inner_right_border" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_slice1">
-	<clip x="0" y="0" width="width-1" height="height-5" />
-	<include name="button" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice2">
-	<clip x="0" y="height-5" width="width-2" height="2" />
-	<include name="button" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice3">
-	<clip x="0" y="height-3" width="width-3" height="1" />
-	<include name="button" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice4">
-	<clip x="0" y="height-2" width="width-5" height="2" />
-	<include name="button" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_fill">
-	<include name="button_inner_left_slice1" />
-	<include name="button_inner_left_slice2" />
-	<include name="button_inner_left_slice3" />
-	<include name="button_inner_left_slice4" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_slice1_prelight">
-	<clip x="0" y="0" width="width-1" height="height-5" />
-	<include name="button_prelight" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice2_prelight">
-	<clip x="0" y="height-5" width="width-2" height="2" />
-	<include name="button_prelight" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice3_prelight">
-	<clip x="0" y="height-3" width="width-3" height="1" />
-	<include name="button_prelight" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice4_prelight">
-	<clip x="0" y="height-2" width="width-5" height="2" />
-	<include name="button_prelight" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_fill_prelight">
-	<include name="button_inner_left_slice1_prelight" />
-	<include name="button_inner_left_slice2_prelight" />
-	<include name="button_inner_left_slice3_prelight" />
-	<include name="button_inner_left_slice4_prelight" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_slice1_pressed">
-	<clip x="0" y="0" width="width-1" height="height-5" />
-	<include name="button_pressed" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice2_pressed">
-	<clip x="0" y="height-5" width="width-2" height="2" />
-	<include name="button_pressed" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice3_pressed">
-	<clip x="0" y="height-3" width="width-3" height="1" />
-	<include name="button_pressed" />
-</draw_ops>
-<draw_ops name="button_inner_left_slice4_pressed">
-	<clip x="0" y="height-2" width="width-5" height="2" />
-	<include name="button_pressed" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_fill_pressed">
-	<include name="button_inner_left_slice1_pressed" />
-	<include name="button_inner_left_slice2_pressed" />
-	<include name="button_inner_left_slice3_pressed" />
-	<include name="button_inner_left_slice4_pressed" />
-</draw_ops>
-
-
-<draw_ops name="button_inner_left_border">
-	<gradient type="vertical" x="width-1" y="0" width="1" height="height-6">
-		<color value="C_titlebar_focused_hilight" />
-		<color value="C_button_hilight" />
-	</gradient>
-	<arc color="C_button_hilight" x="width-11" y="height-11" width="10" height="10"  start_angle="90" extent_angle="90" />
-	<gradient type="vertical" x="width-2" y="0" width="1" height="height-5">
-		<color value="C_border_focused" />
-		<color value="C_button_border" />
-	</gradient>
-	<arc color="C_button_border" x="width-11" y="height-11" width="9" height="9"  start_angle="90" extent_angle="90" />
-</draw_ops>
-
-<draw_ops name="button_inner_left">
-	<include name="button_inner_left_fill" />
-	<include name="button_inner_left_border" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_prelight">
-	<include name="button_inner_left_fill_prelight" />
-	<include name="button_inner_left_border" />
-</draw_ops>
-
-<draw_ops name="button_inner_left_pressed">
-	<include name="button_inner_left_fill_pressed" />
-	<include name="button_inner_left_border" />
 </draw_ops>
 
 <!-- frame styles -->
@@ -1028,30 +850,26 @@
 	<piece position="overlay" draw_ops="rounded_border_focused" />
 	<button function="close" state="normal" draw_ops="close_focused" />
 	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 	<button function="maximize" state="normal" draw_ops="maximize_focused" />
 	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
 	<button function="minimize" state="normal" draw_ops="minimize_focused" />
 	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
 	<button function="menu" state="normal" draw_ops="menu_focused" />
 	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
 	<button function="shade" state="normal" draw_ops="shade_focused" />
 	<button function="shade" state="pressed" draw_ops="shade_focused_pressed" />
 	<button function="unshade" state="normal" draw_ops="shade_focused" />
 	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
-
+	
 	<button function="left_middle_background" state="normal" draw_ops="button"/>
-	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="left_right_background" state="normal" draw_ops="button_inner_left"/>
-	<button function="left_right_background" state="prelight" draw_ops="button_inner_left_prelight"/>
-	<button function="left_right_background" state="pressed" draw_ops="button_inner_left_pressed"/>
-
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="normal" draw_ops="button"/>
-	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="right_left_background" state="normal" draw_ops="button_inner_right"/>
-	<button function="right_left_background" state="prelight" draw_ops="button_inner_right_prelight"/>
-	<button function="right_left_background" state="pressed" draw_ops="button_inner_right_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
@@ -1065,7 +883,7 @@
 
 <frame_style name="normal_unfocused" geometry="normal_unfocused">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
-	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="titlebar" draw_ops="rounded_titlebar_unfocused" />
 	<piece position="title" draw_ops="title_unfocused" />
 	<piece position="overlay" draw_ops="rounded_border_unfocused" />
 	<button function="close" state="normal" draw_ops="close_unfocused"/>
@@ -1098,15 +916,17 @@
 
 <frame_style name="normal_max_focused" geometry="max">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
-	<piece position="titlebar" draw_ops="titlebar_fill_focused_alt" />
+	<piece position="titlebar" draw_ops="titlebar_focused" />
 	<piece position="title" draw_ops="title_focused" />
-	<piece position="overlay" draw_ops="border_focused" />
 	<button function="close" state="normal" draw_ops="close_focused" />
 	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 	<button function="maximize" state="normal" draw_ops="maximize_focused" />
 	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
 	<button function="minimize" state="normal" draw_ops="minimize_focused" />
 	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
 	<button function="menu" state="normal" draw_ops="menu_focused" />
 	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
 	<button function="shade" state="normal" draw_ops="shade_focused" />
@@ -1115,18 +935,11 @@
 	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
 
 	<button function="left_middle_background" state="normal" draw_ops="button"/>
-	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="left_right_background" state="normal" draw_ops="button_inner_left"/>
-	<button function="left_right_background" state="prelight" draw_ops="button_inner_left_prelight"/>
-	<button function="left_right_background" state="pressed" draw_ops="button_inner_left_pressed"/>
-
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="normal" draw_ops="button"/>
-	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="right_left_background" state="normal" draw_ops="button_inner_right"/>
-	<button function="right_left_background" state="prelight" draw_ops="button_inner_right_prelight"/>
-	<button function="right_left_background" state="pressed" draw_ops="button_inner_right_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
@@ -1140,9 +953,8 @@
 
 <frame_style name="normal_max_unfocused" geometry="max">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
-	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="titlebar" draw_ops="titlebar_unfocused" />
 	<piece position="title" draw_ops="title_unfocused" />
-	<piece position="overlay" draw_ops="border_unfocused" />
 	<button function="close" state="normal" draw_ops="close_unfocused"/>
 	<button function="close" state="prelight" draw_ops="close_unfocused_prelight"/>
 	<button function="close" state="pressed" draw_ops="close_unfocused_pressed"/>
@@ -1173,15 +985,18 @@
 
 <frame_style name="normal_max_shaded_focused" geometry="max">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
-	<piece position="titlebar" draw_ops="titlebar_fill_focused_alt" />
+	<piece position="titlebar" draw_ops="titlebar_focused" />
 	<piece position="title" draw_ops="title_focused" />
 	<piece position="overlay"><draw_ops><line x1="0" y1="height-1" x2="width" y2="height-1" color="C_border_focused" /></draw_ops></piece>
 	<button function="close" state="normal" draw_ops="close_focused" />
 	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 	<button function="maximize" state="normal" draw_ops="maximize_focused" />
 	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
 	<button function="minimize" state="normal" draw_ops="minimize_focused" />
 	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
 	<button function="menu" state="normal" draw_ops="menu_focused" />
 	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
 	<button function="shade" state="normal" draw_ops="shade_focused" />
@@ -1190,18 +1005,11 @@
 	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
 
 	<button function="left_middle_background" state="normal" draw_ops="button"/>
-	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="left_right_background" state="normal" draw_ops="button_inner_left"/>
-	<button function="left_right_background" state="prelight" draw_ops="button_inner_left_prelight"/>
-	<button function="left_right_background" state="pressed" draw_ops="button_inner_left_pressed"/>
-
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="normal" draw_ops="button"/>
-	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="right_left_background" state="normal" draw_ops="button_inner_right"/>
-	<button function="right_left_background" state="prelight" draw_ops="button_inner_right_prelight"/>
-	<button function="right_left_background" state="pressed" draw_ops="button_inner_right_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
@@ -1215,7 +1023,7 @@
 
 <frame_style name="normal_max_shaded_unfocused" geometry="max">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
-	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="titlebar" draw_ops="titlebar_unfocused" />
 	<piece position="title" draw_ops="title_unfocused" />
 	<piece position="overlay"><draw_ops><line x1="0" y1="height-1" x2="width" y2="height-1" color="C_border_unfocused" /></draw_ops></piece>
 	<button function="close" state="normal" draw_ops="close_unfocused"/>
@@ -1253,10 +1061,13 @@
 	<piece position="overlay" draw_ops="rounded_border_focused" />
 	<button function="close" state="normal" draw_ops="close_focused" />
 	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 	<button function="maximize" state="normal" draw_ops="maximize_focused" />
 	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
 	<button function="minimize" state="normal" draw_ops="minimize_focused" />
 	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
 	<button function="menu" state="normal" draw_ops="menu_focused" />
 	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
 	<button function="shade" state="normal" draw_ops="shade_focused" />
@@ -1265,18 +1076,11 @@
 	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
 
 	<button function="left_middle_background" state="normal" draw_ops="button"/>
-	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="left_right_background" state="normal" draw_ops="button_inner_left"/>
-	<button function="left_right_background" state="prelight" draw_ops="button_inner_left_prelight"/>
-	<button function="left_right_background" state="pressed" draw_ops="button_inner_left_pressed"/>
-
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="normal" draw_ops="button"/>
-	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="right_left_background" state="normal" draw_ops="button_inner_right"/>
-	<button function="right_left_background" state="prelight" draw_ops="button_inner_right_prelight"/>
-	<button function="right_left_background" state="pressed" draw_ops="button_inner_right_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
@@ -1321,15 +1125,18 @@
 
 <frame_style name="modal_dialog_focused" geometry="modal">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
-	<piece position="titlebar" draw_ops="rounded_titlebar_focused" />
+	<piece position="titlebar" draw_ops="titlebar_focused" />
 	<piece position="title" draw_ops="title_focused" />
-	<piece position="overlay" draw_ops="rounded_border_focused" />
+	<piece position="overlay" draw_ops="border_focused" />
 	<button function="close" state="normal" draw_ops="close_focused" />
 	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 	<button function="maximize" state="normal" draw_ops="maximize_focused" />
 	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
 	<button function="minimize" state="normal" draw_ops="minimize_focused" />
 	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
 	<button function="menu" state="normal" draw_ops="menu_focused" />
 	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
 	<button function="shade" state="normal" draw_ops="shade_focused" />
@@ -1338,18 +1145,11 @@
 	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
 
 	<button function="left_middle_background" state="normal" draw_ops="button"/>
-	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="left_right_background" state="normal" draw_ops="button_inner_left"/>
-	<button function="left_right_background" state="prelight" draw_ops="button_inner_left_prelight"/>
-	<button function="left_right_background" state="pressed" draw_ops="button_inner_left_pressed"/>
-
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="normal" draw_ops="button"/>
-	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
-	<button function="right_left_background" state="normal" draw_ops="button_inner_right"/>
-	<button function="right_left_background" state="prelight" draw_ops="button_inner_right_prelight"/>
-	<button function="right_left_background" state="pressed" draw_ops="button_inner_right_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
@@ -1364,7 +1164,7 @@
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
 	<piece position="titlebar" draw_ops="titlebar_unfocused" />
 	<piece position="title" draw_ops="title_unfocused" />
-	<piece position="overlay" draw_ops="rounded_border_unfocused" />
+	<piece position="overlay" draw_ops="border_unfocused" />
 	<button function="close" state="normal" draw_ops="close_unfocused"/>
 	<button function="close" state="prelight" draw_ops="close_unfocused_prelight"/>
 	<button function="close" state="pressed" draw_ops="close_unfocused_pressed"/>
@@ -1395,15 +1195,18 @@
 
 <frame_style name="utility_focused" geometry="small">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
-	<piece position="titlebar" draw_ops="titlebar_focused_alt" />
+	<piece position="titlebar" draw_ops="titlebar_focused" />
 	<piece position="title" draw_ops="title_focused" />
 	<piece position="overlay" draw_ops="border_focused" />
 	<button function="close" state="normal" draw_ops="close_focused" />
 	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 	<button function="maximize" state="normal" draw_ops="maximize_focused" />
 	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
 	<button function="minimize" state="normal" draw_ops="minimize_focused" />
 	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
 	<button function="menu" state="normal" draw_ops="menu_focused" />
 	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
 	<button function="shade" state="normal" draw_ops="shade_focused" />
@@ -1411,13 +1214,12 @@
 	<button function="unshade" state="normal" draw_ops="shade_focused" />
 	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
 
-	<button function="left_middle_background" state="normal" draw_ops="button_inner_left"/>
-	<button function="left_middle_background" state="prelight" draw_ops="button_inner_left_prelight"/>
-	<button function="left_middle_background" state="pressed" draw_ops="button_inner_left_pressed"/>
-
-	<button function="right_middle_background" state="normal" draw_ops="button_inner_right"/>
-	<button function="right_middle_background" state="prelight" draw_ops="button_inner_right_prelight"/>
-	<button function="right_middle_background" state="pressed" draw_ops="button_inner_right_pressed"/>
+	<button function="left_middle_background" state="normal" draw_ops="button"/>
+	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
+	<button function="right_middle_background" state="normal" draw_ops="button"/>
+	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
 
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
@@ -1462,7 +1264,7 @@
 	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 </frame_style>
 
-<frame_style name="border_focused" geometry="borderless">
+<frame_style name="border_focused" geometry="border">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
 	<piece position="overlay" draw_ops="border_focused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
@@ -1487,7 +1289,7 @@
 	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 </frame_style>
 
-<frame_style name="border_unfocused" geometry="borderless">
+<frame_style name="border_unfocused" geometry="border">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
 	<piece position="overlay" draw_ops="border_unfocused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
@@ -1502,6 +1304,225 @@
 	<button function="shade" state="pressed"><draw_ops></draw_ops></button>
 	<button function="unshade" state="normal"><draw_ops></draw_ops></button>
 	<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="borderless" geometry="borderless">
+	<button function="close" state="normal"><draw_ops></draw_ops></button>
+	<button function="close" state="pressed"><draw_ops></draw_ops></button>
+	<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+	<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+	<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+	<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+	<button function="menu" state="normal"><draw_ops></draw_ops></button>
+	<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+	<button function="shade" state="normal"><draw_ops></draw_ops></button>
+	<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+	<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="attached_focused" geometry="attached">
+	<piece position="entire_background" draw_ops="entire_background_focused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+	<piece position="title" draw_ops="title_focused" />
+	<piece position="overlay" draw_ops="border_focused" />
+	<button function="close" state="normal"><draw_ops></draw_ops></button>
+	<button function="close" state="pressed"><draw_ops></draw_ops></button>
+	<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+	<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+	<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+	<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+	<button function="menu" state="normal"><draw_ops></draw_ops></button>
+	<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+	<button function="shade" state="normal"><draw_ops></draw_ops></button>
+	<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+	<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="attached_unfocused" geometry="attached">
+	<piece position="entire_background" draw_ops="entire_background_unfocused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="title" draw_ops="title_unfocused" />
+	<piece position="overlay" draw_ops="border_unfocused" />
+	<button function="close" state="normal"><draw_ops></draw_ops></button>
+	<button function="close" state="pressed"><draw_ops></draw_ops></button>
+	<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+	<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+	<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+	<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+	<button function="menu" state="normal"><draw_ops></draw_ops></button>
+	<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+	<button function="shade" state="normal"><draw_ops></draw_ops></button>
+	<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+	<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="tiled_left_focused" geometry="tiled_left">
+	<piece position="entire_background" draw_ops="entire_background_focused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+	<piece position="title" draw_ops="title_focused" />
+	<!-- <piece position="overlay" draw_ops="border_right_focused" /> -->
+	<button function="close" state="normal" draw_ops="close_focused" />
+	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+	<button function="maximize" state="normal" draw_ops="maximize_focused" />
+	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+	<button function="minimize" state="normal" draw_ops="minimize_focused" />
+	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+	<button function="menu" state="normal" draw_ops="menu_focused" />
+	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+	<button function="shade" state="normal" draw_ops="shade_focused" />
+	<button function="shade" state="pressed" draw_ops="shade_focused_pressed" />
+	<button function="unshade" state="normal" draw_ops="shade_focused" />
+	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
+
+	<button function="left_middle_background" state="normal" draw_ops="button"/>
+	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
+	<button function="right_middle_background" state="normal" draw_ops="button"/>
+	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
+
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="tiled_left_unfocused" geometry="tiled_left">
+	<piece position="entire_background" draw_ops="entire_background_unfocused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="title" draw_ops="title_unfocused" />
+	<!-- <piece position="overlay" draw_ops="border_right_unfocused" /> -->
+	<button function="close" state="normal" draw_ops="close_unfocused"/>
+	<button function="close" state="prelight" draw_ops="close_unfocused_prelight"/>
+	<button function="close" state="pressed" draw_ops="close_unfocused_pressed"/>
+	<button function="maximize" state="normal" draw_ops="maximize_unfocused"/>
+	<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight"/>
+	<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed"/>
+	<button function="minimize" state="normal" draw_ops="minimize_unfocused"/>
+	<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight"/>
+	<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed"/>
+	<button function="menu" state="normal" draw_ops="menu_unfocused" />
+	<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+	<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+	<button function="shade" state="normal" draw_ops="shade_unfocused" />
+	<button function="shade" state="prelight" draw_ops="shade_unfocused_prelight" />
+	<button function="shade" state="pressed" draw_ops="shade_unfocused_pressed" />
+	<button function="unshade" state="normal" draw_ops="shade_unfocused" />
+	<button function="unshade" state="prelight" draw_ops="shade_unfocused_prelight" />
+	<button function="unshade" state="pressed" draw_ops="shade_unfocused_pressed" />
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="tiled_right_focused" geometry="tiled_right">
+	<piece position="entire_background" draw_ops="entire_background_focused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+	<piece position="title" draw_ops="title_focused" />
+	<piece position="overlay" draw_ops="border_left_focused" />
+	<button function="close" state="normal" draw_ops="close_focused" />
+	<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+	<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+	<button function="maximize" state="normal" draw_ops="maximize_focused" />
+	<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+	<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+	<button function="minimize" state="normal" draw_ops="minimize_focused" />
+	<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+	<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+	<button function="menu" state="normal" draw_ops="menu_focused" />
+	<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+	<button function="shade" state="normal" draw_ops="shade_focused" />
+	<button function="shade" state="pressed" draw_ops="shade_focused_pressed" />
+	<button function="unshade" state="normal" draw_ops="shade_focused" />
+	<button function="unshade" state="pressed" draw_ops="shade_focused_pressed" />
+
+	<button function="left_middle_background" state="normal" draw_ops="button"/>
+	<button function="left_middle_background" state="pressed" draw_ops="button_pressed"/>
+	<button function="left_middle_background" state="prelight" draw_ops="button_prelight"/>
+	<button function="right_middle_background" state="normal" draw_ops="button"/>
+	<button function="right_middle_background" state="pressed" draw_ops="button_pressed"/>
+	<button function="right_middle_background" state="prelight" draw_ops="button_prelight"/>
+
+	<button function="above" state="normal"><draw_ops></draw_ops></button>
+	<button function="above" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+	<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+	<button function="stick" state="normal"><draw_ops></draw_ops></button>
+	<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+	<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+	<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+</frame_style>
+
+<frame_style name="tiled_right_unfocused" geometry="tiled_right">
+	<piece position="entire_background" draw_ops="entire_background_unfocused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="title" draw_ops="title_unfocused" />
+	<piece position="overlay" draw_ops="border_left_unfocused" />
+	<button function="close" state="normal" draw_ops="close_unfocused"/>
+	<button function="close" state="prelight" draw_ops="close_unfocused_prelight"/>
+	<button function="close" state="pressed" draw_ops="close_unfocused_pressed"/>
+	<button function="maximize" state="normal" draw_ops="maximize_unfocused"/>
+	<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight"/>
+	<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed"/>
+	<button function="minimize" state="normal" draw_ops="minimize_unfocused"/>
+	<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight"/>
+	<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed"/>
+	<button function="menu" state="normal" draw_ops="menu_unfocused" />
+	<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+	<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+	<button function="shade" state="normal" draw_ops="shade_unfocused" />
+	<button function="shade" state="prelight" draw_ops="shade_unfocused_prelight" />
+	<button function="shade" state="pressed" draw_ops="shade_unfocused_pressed" />
+	<button function="unshade" state="normal" draw_ops="shade_unfocused" />
+	<button function="unshade" state="prelight" draw_ops="shade_unfocused_prelight" />
+	<button function="unshade" state="pressed" draw_ops="shade_unfocused_pressed" />
 	<button function="above" state="normal"><draw_ops></draw_ops></button>
 	<button function="above" state="pressed"><draw_ops></draw_ops></button>
 	<button function="unabove" state="normal"><draw_ops></draw_ops></button>
@@ -1585,6 +1606,17 @@
 <frame_style_set name="border_style_set">
 	<frame focus="yes" state="normal" resize="both" style="border_focused"/>
 	<frame focus="no" state="normal" resize="both" style="border_unfocused"/>
+	<frame focus="yes" state="maximized" style="borderless"/>
+	<frame focus="no" state="maximized" style="borderless"/>
+	<frame focus="yes" state="shaded" style="blank"/>
+	<frame focus="no" state="shaded" style="blank"/>
+	<frame focus="yes" state="maximized_and_shaded" style="blank"/>
+	<frame focus="no" state="maximized_and_shaded" style="blank"/>
+</frame_style_set>
+
+<frame_style_set name="attached_style_set">
+	<frame focus="yes" state="normal" resize="both" style="attached_focused"/>
+	<frame focus="no" state="normal" resize="both" style="attached_unfocused"/>
 	<frame focus="yes" state="maximized" style="blank"/>
 	<frame focus="no" state="maximized" style="blank"/>
 	<frame focus="yes" state="shaded" style="blank"/>


### PR DESCRIPTION
The two versions of Adwaita themes became very different look over the time, because the old version is abandoned. This patch backports the new Adwaita metacity 3 theme for metacity 2 by replacing all new features, and makes their look similar again.